### PR TITLE
feat: 支持自定义翻译提示词

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -136,7 +136,7 @@
       },
       "twitter_translate_custom_prompt": {
         "description": "自定义翻译提示词",
-        "type": "text",
+        "type": "string",
         "default": "你是一个专业的翻译助手。请将用户提供的文本翻译为{target_lang}。规则：仅输出翻译结果，不要添加任何解释、前缀、注释或原文对照。保持原文的语气和格式（如换行、表情符号等）。",
         "hint": "自定义翻译 system prompt。支持变量：{target_lang} 会替换为翻译目标语言。",
         "editor_mode": "text"

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -127,6 +127,19 @@
         "type": "string",
         "default": "",
         "hint": "指定翻译用的 Provider ID，留空时按以下顺序自动选择：当前会话 Provider → 第一个可用 Provider"
+      },
+      "twitter_translate_custom_prompt_enabled": {
+        "description": "启用自定义翻译提示词",
+        "type": "bool",
+        "default": false,
+        "hint": "开启后将使用下方自定义的翻译提示词，而非内置默认提示词"
+      },
+      "twitter_translate_custom_prompt": {
+        "description": "自定义翻译提示词",
+        "type": "text",
+        "default": "你是一个专业的翻译助手。请将用户提供的文本翻译为{target_lang}。规则：仅输出翻译结果，不要添加任何解释、前缀、注释或原文对照。保持原文的语气和格式（如换行、表情符号等）。",
+        "hint": "自定义翻译 system prompt。支持变量：{target_lang} 会替换为翻译目标语言。",
+        "editor_mode": "text"
       }
     }
   }

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -137,7 +137,7 @@
       "twitter_translate_custom_prompt": {
         "description": "自定义翻译提示词",
         "type": "string",
-        "default": "你是一个专业的翻译助手。请将用户提供的文本翻译为{target_lang}。规则：仅输出翻译结果，不要添加任何解释、前缀、注释或原文对照。保持原文的语气和格式（如换行、表情符号等）。",
+        "default": "你是一个专业的翻译助手。请将用户提供的文本翻译为{target_lang}。\n规则：仅输出翻译结果，不要添加任何解释、前缀、注释或原文对照\n保持原文的语气和格式（如换行、表情符号等）",
         "hint": "自定义翻译 system prompt。支持变量：{target_lang} 会替换为翻译目标语言。",
         "editor_mode": "text"
       }

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -136,10 +136,11 @@
       },
       "twitter_translate_custom_prompt": {
         "description": "自定义翻译提示词",
-        "type": "string",
+        "type": "text",
+        "editor_mode": true,
+        "editor_language": "markdown",
         "default": "你是一个专业的翻译助手。请将用户提供的文本翻译为{target_lang}。\n规则：仅输出翻译结果，不要添加任何解释、前缀、注释或原文对照\n保持原文的语气和格式（如换行、表情符号等）",
-        "hint": "自定义翻译 system prompt。支持变量：{target_lang} 会替换为翻译目标语言。",
-        "editor_mode": "text"
+        "hint": "自定义翻译 system prompt。支持变量：{target_lang} 会替换为翻译目标语言。"
       }
     }
   }

--- a/main.py
+++ b/main.py
@@ -182,6 +182,16 @@ class TwitterPlugin(Star):
         self.translate_provider_id = str(
             self._cfg("translation", "twitter_translate_provider_id", "") or ""
         ).strip()
+        self.translate_custom_prompt_enabled = bool(
+            self._cfg(
+                "translation",
+                "twitter_translate_custom_prompt_enabled",
+                False,
+            )
+        )
+        self.translate_custom_prompt = str(
+            self._cfg("translation", "twitter_translate_custom_prompt", "") or ""
+        ).strip()
         self.custom_nitter_url = str(
             self._cfg("basic", "twitter_nitter_url", "") or ""
         ).strip()
@@ -468,11 +478,16 @@ class TwitterPlugin(Star):
         if not provider_id:
             return text, None
 
-        system_prompt = (
-            f"你是一个专业的翻译助手。请将用户提供的文本翻译为{self.translate_target_lang}。"
-            f"规则：仅输出翻译结果，不要添加任何解释、前缀、注释或原文对照。"
-            f"保持原文的语气和格式（如换行、表情符号等）。"
-        )
+        if self.translate_custom_prompt_enabled and self.translate_custom_prompt:
+            system_prompt = self.translate_custom_prompt.replace(
+                "{target_lang}", self.translate_target_lang
+            )
+        else:
+            system_prompt = (
+                f"你是一个专业的翻译助手。请将用户提供的文本翻译为{self.translate_target_lang}。"
+                f"规则：仅输出翻译结果，不要添加任何解释、前缀、注释或原文对照。"
+                f"保持原文的语气和格式（如换行、表情符号等）。"
+            )
 
         max_retries = 2
         for attempt in range(max_retries):


### PR DESCRIPTION
## 描述

新增自定义翻译提示词功能，允许用户根据自身需求调整翻译的 system prompt。

### 改动内容

- **_conf_schema.json**：新增两项配置项
  - `twitter_translate_custom_prompt_enabled`（开关）：启用后使用自定义提示词
  - `twitter_translate_custom_prompt`（文本）：自定义 system prompt，支持 `{target_lang}` 变量占位（自动替换为目标语言）
- **main.py**：读取配置并在翻译时根据开关状态动态选择提示词

### 使用方式

1. 在插件配置中启用「自定义翻译提示词」
2. 编写自定义 prompt，例如：
   ```
   你是一个专业的翻译助手。请将用户提供的文本翻译为{target_lang}。
   规则：仅输出翻译结果，不要添加任何解释、前缀、注释或原文对照。
   保持原文的语气和格式（如换行、表情符号等）。
   ```
3. 保存后生效，无需重启

### 兼容性

- 默认保持原有行为不变（开关关闭时使用内置默认提示词）
- 如果启用了自定义但内容为空，同样回退到默认提示词
