### PR TITLE
feat: 代理预下载媒体 — 修复网络受限环境下图片/截图超时

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -16,6 +16,12 @@
         "hint": "例如: http://127.0.0.1:7890 或 socks5://127.0.0.1:1080",
         "default": ""
       },
+      "twitter_pre_download_media": {
+        "description": "通过代理预下载图片（需先配置代理地址）",
+        "type": "bool",
+        "default": false,
+        "hint": "开启后，图片通过代理预下载到本地再发送，避免下游消息适配器直连外部服务器超时。截图模式下图片转为 base64 内嵌，Chromium 渲染零外部请求。关闭时使用原始 URL 传递。"
+      },
       "twitter_poll_interval": {
         "description": "推文轮询间隔（分钟）",
         "type": "int",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -17,10 +17,10 @@
         "default": ""
       },
       "twitter_pre_download_media": {
-        "description": "通过代理预下载图片（需先配置代理地址）",
+        "description": "通过代理加载图片（需先配置代理地址）",
         "type": "bool",
         "default": false,
-        "hint": "开启后，图片通过代理预下载到本地再发送，避免下游消息适配器直连外部服务器超时。截图模式下图片转为 base64 内嵌，Chromium 渲染零外部请求。关闭时使用原始 URL 传递。"
+        "hint": "开启后，插件会先通过代理下载图片，再交给 AstrBot 发送或 Chromium 生成截图，避免因直连外部服务器导致图片加载超时。关闭后，图片由 AstrBot 或 Chromium 直接从原链接加载，不使用代理。"
       },
       "twitter_poll_interval": {
         "description": "推文轮询间隔（分钟）",

--- a/main.py
+++ b/main.py
@@ -37,7 +37,10 @@ AstrBot Twitter 推文转发插件
 """
 
 import asyncio
+import os
 import re
+import shutil
+import tempfile
 from dataclasses import dataclass, field
 
 from astrbot.api import AstrBotConfig, logger
@@ -212,6 +215,9 @@ class TwitterPlugin(Star):
         self.image_quality = str(
             self._cfg("message_format", "twitter_image_quality", "orig") or "orig"
         ).strip()
+        self.pre_download_media = bool(
+            self._cfg("basic", "twitter_pre_download_media", False)
+        )
 
         # 构建镜像站列表
         self.website_list: list[str] = []
@@ -230,6 +236,10 @@ class TwitterPlugin(Star):
 
         # 集体转发推文缓存：{umo: [CachedTweet, ...]}
         self._collected_tweets: dict[str, list[CachedTweet]] = {}
+
+        # 媒体临时文件管理
+        self._media_temp_dir = tempfile.mkdtemp(prefix="twitter_plugin_media_")
+        self._pending_cleanup: list[str] = []
 
     async def initialize(self):
         """插件初始化"""
@@ -270,6 +280,12 @@ class TwitterPlugin(Star):
         if self._collected_tweets:
             logger.info("正在发送剩余缓存的推文...")
             await self._flush_collected_tweets()
+        # 清理媒体临时文件
+        await self._cleanup_temp_files()
+        try:
+            shutil.rmtree(self._media_temp_dir, ignore_errors=True)
+        except Exception:
+            pass
         await self.twitter_api.close()
         logger.info("Twitter 推文转发插件已停止")
 
@@ -396,13 +412,17 @@ class TwitterPlugin(Star):
     async def _append_media_components(
         self, chain: list, images: list, videos: list, context_label: str = "推文"
     ):
-        """把图片和视频追加到消息链，供主贴和引用帖复用。"""
+        """把图片和视频追加到消息链，供主贴和引用帖复用。
+
+        当插件配置了代理时，图片会通过代理预下载到本地临时文件，
+        避免下游消息适配器直连外部服务器导致超时。
+        """
         if not self.send_media_separately:
             return
 
         for img_url in images:
             try:
-                img_comp = Comp.Image.fromURL(str(img_url))
+                img_comp = await self._build_image_component(str(img_url))
                 if img_comp is not None:
                     chain.append(img_comp)
             except Exception as e:
@@ -427,6 +447,65 @@ class TwitterPlugin(Star):
                     f"添加{context_label}视频失败，回退为链接: {video_url}, {e}"
                 )
                 chain.append(Comp.Plain(str(f"\n视频: {video_url}")))
+
+    async def _build_image_component(self, img_url: str) -> Comp.Image | None:
+        """根据代理配置选择合适的图片组件构建方式。
+
+        有代理时：通过代理下载图片到本地临时文件，使用 fromFileSystem，
+        避免下游消息适配器直连外部服务器。
+        无代理时：使用 fromURL，由 AstrBot 核心/适配器自行下载。
+        """
+        img_url = str(img_url or "").strip()
+        if not img_url:
+            return None
+
+        if not (self.pre_download_media and self.proxy):
+            return Comp.Image.fromURL(img_url)
+
+        # 通过代理下载到本地，使用本地路径
+        try:
+            data = await self.twitter_api.download_media(img_url)
+        except Exception as e:
+            logger.warning(f"通过代理下载图片失败 {img_url}: {e}，回退为远程 URL")
+            return Comp.Image.fromURL(img_url)
+
+        suffix = self._guess_image_suffix(img_url)
+        tmp = tempfile.NamedTemporaryFile(
+            suffix=suffix, delete=False, dir=self._media_temp_dir
+        )
+        try:
+            tmp.write(data)
+            tmp.close()
+            self._pending_cleanup.append(tmp.name)
+            return Comp.Image.fromFileSystem(tmp.name)
+        except Exception:
+            tmp.close()
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass
+            raise
+
+    @staticmethod
+    def _guess_image_suffix(url: str) -> str:
+        """根据 URL 或常见模式推测图片文件后缀。"""
+        url_lower = str(url or "").lower()
+        for ext in (".webp", ".png", ".gif", ".bmp", ".svg"):
+            if ext in url_lower:
+                return ext
+        # Nitter /pic/orig/ 路由默认返回 JPEG
+        return ".jpg"
+
+    async def _cleanup_temp_files(self):
+        """清理当前批次累积的媒体临时文件。"""
+        if not self._pending_cleanup:
+            return
+        for path in self._pending_cleanup:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        self._pending_cleanup.clear()
 
     async def _maybe_translate(
         self, tweet_info: dict, umo: str
@@ -739,7 +818,11 @@ class TwitterPlugin(Star):
         translated_text: str | None = None,
         translate_model: str | None = None,
     ) -> list:
-        """构建正文以 X 风格卡片截图展示的消息链。"""
+        """构建正文以 X 风格卡片截图展示的消息链。
+
+        当开启预下载媒体且配置了代理时，提前将所有图片转为 base64
+        data URI 内嵌到 HTML 模板中，避免 Chromium 直连外部服务器。
+        """
         if sub_config is None:
             sub_config = {"r18": True, "media": False, "status": True}
 
@@ -748,6 +831,10 @@ class TwitterPlugin(Star):
         render_text_card = not (self.no_text and has_media)
 
         if render_text_card:
+            # 预下载模式：将图片转为 data URI 内嵌，HTML 渲染零外部请求
+            if self.pre_download_media and self.proxy:
+                tweet_info = await self._prepare_screenshot_media(tweet_info)
+
             context = build_tweet_card_context(
                 username,
                 tweet_info,
@@ -787,7 +874,78 @@ class TwitterPlugin(Star):
             context_label="推文",
         )
 
+        # 及时清理截图流程中创建的临时文件
+        await self._cleanup_temp_files()
+
         return [c for c in chain if c is not None]
+
+    async def _prepare_screenshot_media(self, tweet_info: dict) -> dict:
+        """预下载推文中的所有图片并转为 data URI，返回深拷贝后的 tweet_info。
+
+        下载使用插件已配置代理的 TwitterAPI 客户端，确保在网络受限环境
+        下也能正常获取图片数据。下载失败时保留原始 URL 作为降级。
+        """
+        import copy
+        result = copy.deepcopy(tweet_info)
+
+        # 主贴头像
+        avatar_url = str(result.get("avatar") or "").strip()
+        if avatar_url:
+            data_uri = await self._download_to_data_uri_safe(avatar_url)
+            if data_uri:
+                result["avatar"] = data_uri
+
+        # 主贴图片
+        result["images"] = [
+            await self._download_to_data_uri_safe(str(u)) or str(u)
+            for u in (result.get("images") or [])
+        ]
+
+        # 视频封面
+        previews = result.get("video_previews") or []
+        for p in previews:
+            if isinstance(p, dict):
+                poster = str(p.get("poster") or "").strip()
+                if poster:
+                    data_uri = await self._download_to_data_uri_safe(poster)
+                    if data_uri:
+                        p["poster"] = data_uri
+
+        # 引用推文
+        quote = result.get("quote") or None
+        if quote:
+            quote_avatar = str(quote.get("avatar") or "").strip()
+            if quote_avatar:
+                data_uri = await self._download_to_data_uri_safe(quote_avatar)
+                if data_uri:
+                    quote["avatar"] = data_uri
+
+            quote["images"] = [
+                await self._download_to_data_uri_safe(str(u)) or str(u)
+                for u in (quote.get("images") or [])
+            ]
+
+            quote_previews = quote.get("video_previews") or []
+            for p in quote_previews:
+                if isinstance(p, dict):
+                    poster = str(p.get("poster") or "").strip()
+                    if poster:
+                        data_uri = await self._download_to_data_uri_safe(poster)
+                        if data_uri:
+                            p["poster"] = data_uri
+
+        return result
+
+    async def _download_to_data_uri_safe(self, url: str) -> str | None:
+        """安全地将远程 URL 下载并转为 data URI，失败返回 None。"""
+        url = str(url or "").strip()
+        if not url:
+            return None
+        try:
+            return await self.twitter_api.download_media_to_data_uri(url)
+        except Exception as e:
+            logger.debug(f"预下载截图媒体失败 {url}: {e}")
+            return None
 
     def _split_chain_for_nodes(
         self, chain: list, nickname: str
@@ -1046,6 +1204,8 @@ class TwitterPlugin(Star):
             logger.info(f"推文已推送至 {umo}")
         except Exception as e:
             logger.error(f"推送推文至 {umo} 失败: {e}")
+        finally:
+            await self._cleanup_temp_files()
 
     async def _flush_collected_tweets(self):
         """将缓存的推文按推主分组打包为合并转发消息发送"""
@@ -1650,6 +1810,8 @@ class TwitterPlugin(Star):
             for vid_comp in video_parts:
                 await self._send_video_or_fallback(umo, vid_comp)
 
+        await self._cleanup_temp_files()
+
     # ========== 链接识别 ==========
 
     @filter.event_message_type(filter.EventMessageType.ALL)
@@ -1724,3 +1886,5 @@ class TwitterPlugin(Star):
 
         except Exception as e:
             logger.error(f"解析推文链接失败: {e}")
+        finally:
+            await self._cleanup_temp_files()

--- a/main.py
+++ b/main.py
@@ -37,11 +37,8 @@ AstrBot Twitter 推文转发插件
 """
 
 import asyncio
-import os
 import re
-import shutil
-import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from astrbot.api import AstrBotConfig, logger
 from astrbot.api.event import AstrMessageEvent, MessageChain, filter
@@ -77,14 +74,6 @@ class CachedTweet:
     nickname: str
     translated_text: str | None = None
     translate_model: str | None = None
-
-
-@dataclass
-class BuiltTweetMessage:
-    """已构建的消息链及其独占的临时文件。"""
-
-    chain: list
-    temp_files: list[str] = field(default_factory=list)
 
 
 class TwitterPlugin(Star):
@@ -245,9 +234,6 @@ class TwitterPlugin(Star):
         # 集体转发推文缓存：{umo: [CachedTweet, ...]}
         self._collected_tweets: dict[str, list[CachedTweet]] = {}
 
-        # 媒体临时文件管理
-        self._media_temp_dir = tempfile.mkdtemp(prefix="twitter_plugin_media_")
-
     async def initialize(self):
         """插件初始化"""
         logger.info("Twitter 推文转发插件初始化中...")
@@ -287,11 +273,6 @@ class TwitterPlugin(Star):
         if self._collected_tweets:
             logger.info("正在发送剩余缓存的推文...")
             await self._flush_collected_tweets()
-        # 清理异常退出时可能残留的媒体临时文件
-        try:
-            shutil.rmtree(self._media_temp_dir, ignore_errors=True)
-        except Exception:
-            pass
         await self.twitter_api.close()
         logger.info("Twitter 推文转发插件已停止")
 
@@ -420,12 +401,11 @@ class TwitterPlugin(Star):
         chain: list,
         images: list,
         videos: list,
-        temp_files: list[str],
         context_label: str = "推文",
     ):
         """把图片和视频追加到消息链，供主贴和引用帖复用。
 
-        当插件配置了代理时，图片会通过代理预下载到本地临时文件，
+        当插件配置了代理时，图片会通过代理预下载为内存字节，
         避免下游消息适配器直连外部服务器导致超时。
         """
         if not self.send_media_separately:
@@ -433,9 +413,7 @@ class TwitterPlugin(Star):
 
         for img_url in images:
             try:
-                img_comp = await self._build_image_component(
-                    str(img_url), temp_files
-                )
+                img_comp = await self._build_image_component(str(img_url))
                 if img_comp is not None:
                     chain.append(img_comp)
             except Exception as e:
@@ -461,12 +439,10 @@ class TwitterPlugin(Star):
                 )
                 chain.append(Comp.Plain(str(f"\n视频: {video_url}")))
 
-    async def _build_image_component(
-        self, img_url: str, temp_files: list[str]
-    ) -> Comp.Image | None:
+    async def _build_image_component(self, img_url: str) -> Comp.Image | None:
         """根据代理配置选择合适的图片组件构建方式。
 
-        有代理时：通过代理下载图片到本地临时文件，使用 fromFileSystem，
+        有代理时：通过代理下载图片字节，使用 fromBytes，
         避免下游消息适配器直连外部服务器。
         无代理时：使用 fromURL，由 AstrBot 核心/适配器自行下载。
         """
@@ -477,49 +453,14 @@ class TwitterPlugin(Star):
         if not (self.pre_download_media and self.proxy):
             return Comp.Image.fromURL(img_url)
 
-        # 通过代理下载到本地，使用本地路径
+        # 通过代理下载并直接构建图片组件，交由 AstrBot 管理媒体数据。
         try:
             data = await self.twitter_api.download_media(img_url)
         except Exception as e:
             logger.warning(f"通过代理下载图片失败 {img_url}: {e}，回退为远程 URL")
             return Comp.Image.fromURL(img_url)
 
-        suffix = self._guess_image_suffix(img_url)
-        tmp = tempfile.NamedTemporaryFile(
-            suffix=suffix, delete=False, dir=self._media_temp_dir
-        )
-        try:
-            tmp.write(data)
-            tmp.close()
-            temp_files.append(tmp.name)
-            return Comp.Image.fromFileSystem(tmp.name)
-        except Exception:
-            tmp.close()
-            try:
-                os.unlink(tmp.name)
-            except OSError:
-                pass
-            raise
-
-    @staticmethod
-    def _guess_image_suffix(url: str) -> str:
-        """根据 URL 或常见模式推测图片文件后缀。"""
-        url_lower = str(url or "").lower()
-        for ext in (".webp", ".png", ".gif", ".bmp", ".svg"):
-            if ext in url_lower:
-                return ext
-        # Nitter /pic/orig/ 路由默认返回 JPEG
-        return ".jpg"
-
-    @staticmethod
-    def _cleanup_temp_files(temp_files: list[str]) -> None:
-        """只清理当前消息拥有的媒体临时文件。"""
-        for path in temp_files:
-            try:
-                os.unlink(path)
-            except OSError:
-                pass
-        temp_files.clear()
+        return Comp.Image.fromBytes(data)
 
     async def _maybe_translate(
         self, tweet_info: dict, umo: str
@@ -669,7 +610,6 @@ class TwitterPlugin(Star):
         self,
         username: str,
         tweet_info: dict,
-        temp_files: list[str],
         sub_config: dict | None = None,
         translated_text: str | None = None,
         translate_model: str | None = None,
@@ -749,7 +689,6 @@ class TwitterPlugin(Star):
                 chain,
                 quote.get("images") or [],
                 quote.get("videos") or [],
-                temp_files,
                 context_label="引用推文",
             )
 
@@ -758,7 +697,6 @@ class TwitterPlugin(Star):
             chain,
             images,
             tweet_info.get("videos") or [],
-            temp_files,
             context_label="推文",
         )
 
@@ -801,50 +739,39 @@ class TwitterPlugin(Star):
         sub_config: dict | None = None,
         translated_text: str | None = None,
         translate_model: str | None = None,
-    ) -> BuiltTweetMessage:
-        """按当前文本渲染模式构建推文消息链及其临时文件。"""
-        temp_files: list[str] = []
-        try:
-            if self.text_render_mode != "screenshot":
-                chain = await self._build_tweet_chain(
-                    username,
-                    tweet_info,
-                    temp_files,
-                    sub_config,
-                    translated_text=translated_text,
-                    translate_model=translate_model,
-                )
-                return BuiltTweetMessage(chain=chain, temp_files=temp_files)
+    ) -> list:
+        """按当前文本渲染模式构建推文消息链。"""
+        if self.text_render_mode != "screenshot":
+            return await self._build_tweet_chain(
+                username,
+                tweet_info,
+                sub_config,
+                translated_text=translated_text,
+                translate_model=translate_model,
+            )
 
-            try:
-                chain = await self._build_screenshot_tweet_chain(
-                    username,
-                    tweet_info,
-                    temp_files,
-                    sub_config,
-                    translated_text=translated_text,
-                    translate_model=translate_model,
-                )
-            except Exception as e:
-                logger.warning(f"推文截图渲染失败，已回退为文本消息: {e}")
-                chain = await self._build_tweet_chain(
-                    username,
-                    tweet_info,
-                    temp_files,
-                    sub_config,
-                    translated_text=translated_text,
-                    translate_model=translate_model,
-                )
-            return BuiltTweetMessage(chain=chain, temp_files=temp_files)
-        except BaseException:
-            self._cleanup_temp_files(temp_files)
-            raise
+        try:
+            return await self._build_screenshot_tweet_chain(
+                username,
+                tweet_info,
+                sub_config,
+                translated_text=translated_text,
+                translate_model=translate_model,
+            )
+        except Exception as e:
+            logger.warning(f"推文截图渲染失败，已回退为文本消息: {e}")
+            return await self._build_tweet_chain(
+                username,
+                tweet_info,
+                sub_config,
+                translated_text=translated_text,
+                translate_model=translate_model,
+            )
 
     async def _build_screenshot_tweet_chain(
         self,
         username: str,
         tweet_info: dict,
-        temp_files: list[str],
         sub_config: dict | None = None,
         translated_text: str | None = None,
         translate_model: str | None = None,
@@ -896,7 +823,6 @@ class TwitterPlugin(Star):
                 chain,
                 quote.get("images") or [],
                 quote.get("videos") or [],
-                temp_files,
                 context_label="引用推文",
             )
 
@@ -904,7 +830,6 @@ class TwitterPlugin(Star):
             chain,
             tweet_info.get("images") or [],
             tweet_info.get("videos") or [],
-            temp_files,
             context_label="推文",
         )
 
@@ -1189,14 +1114,12 @@ class TwitterPlugin(Star):
         translate_model: str | None = None,
     ):
         """向单个订阅者发送推文消息"""
-        built_message = BuiltTweetMessage(chain=[])
         try:
-            built_message = await self._build_tweet_message_chain(
+            chain = await self._build_tweet_message_chain(
                 username, tweet_info, sub_config,
                 translated_text=translated_text,
                 translate_model=translate_model,
             )
-            chain = built_message.chain
             if not chain:
                 return
 
@@ -1237,78 +1160,6 @@ class TwitterPlugin(Star):
             logger.info(f"推文已推送至 {umo}")
         except Exception as e:
             logger.error(f"推送推文至 {umo} 失败: {e}")
-        finally:
-            self._cleanup_temp_files(built_message.temp_files)
-
-    async def _send_collected_batch(
-        self,
-        umo: str,
-        batch_authors: list[str],
-        seen_authors: dict[str, list[CachedTweet]],
-        batch_index: int,
-        batch_count: int,
-    ) -> None:
-        """发送一批集体转发消息，并清理该批次独占的临时文件。"""
-        temp_files: list[str] = []
-        nodes: list[Node] = []
-        video_queue: list[Comp.Video] = []
-
-        try:
-            for author in batch_authors:
-                for cached_tweet in seen_authors[author]:
-                    built_message = await self._build_tweet_message_chain(
-                        cached_tweet.username,
-                        cached_tweet.tweet_info,
-                        cached_tweet.sub_config,
-                        translated_text=cached_tweet.translated_text,
-                        translate_model=cached_tweet.translate_model,
-                    )
-                    temp_files.extend(built_message.temp_files)
-                    if not built_message.chain:
-                        continue
-
-                    tweet_nodes, tweet_videos = self._split_chain_for_nodes(
-                        built_message.chain, cached_tweet.nickname
-                    )
-                    nodes.extend(tweet_nodes)
-                    video_queue.extend(tweet_videos)
-
-            if nodes:
-                batch_label = ""
-                if batch_count > 1:
-                    batch_label = f"（第{batch_index + 1}/{batch_count}批）"
-                try:
-                    message_chain = MessageChain(chain=[Nodes(nodes)])
-                    await self.context.send_message(umo, message_chain)
-                    logger.info(
-                        f"集体转发已推送至 {umo} "
-                        f"{batch_label}共 {len(nodes)} 个节点"
-                    )
-                except Exception as node_err:
-                    logger.warning(
-                        f"集体合并转发失败，回退逐条发送: {node_err}"
-                    )
-                    for cached_tweet in [
-                        cached_tweet
-                        for author in batch_authors
-                        for cached_tweet in seen_authors[author]
-                    ]:
-                        await self._send_tweet_to_subscriber(
-                            umo,
-                            cached_tweet.username,
-                            cached_tweet.tweet_info,
-                            cached_tweet.sub_config,
-                            cached_tweet.nickname,
-                            translated_text=cached_tweet.translated_text,
-                            translate_model=cached_tweet.translate_model,
-                        )
-                    # 回退逐条发送已包含视频，不再重复发送。
-                    video_queue.clear()
-
-            for video_component in video_queue:
-                await self._send_video_or_fallback(umo, video_component)
-        finally:
-            self._cleanup_temp_files(temp_files)
 
     async def _flush_collected_tweets(self):
         """将缓存的推文按推主分组打包为合并转发消息发送"""
@@ -1363,13 +1214,64 @@ class TwitterPlugin(Star):
                     author_batches.append(author_order[i : i + max_authors])
 
                 for batch_idx, batch_authors in enumerate(author_batches):
-                    await self._send_collected_batch(
-                        umo,
-                        batch_authors,
-                        seen_authors,
-                        batch_idx,
-                        len(author_batches),
-                    )
+                    nodes: list[Node] = []
+                    video_queue: list[Comp.Video] = []
+
+                    for author in batch_authors:
+                        for ct in seen_authors[author]:
+                            chain = await self._build_tweet_message_chain(
+                                ct.username, ct.tweet_info, ct.sub_config,
+                                translated_text=ct.translated_text,
+                                translate_model=ct.translate_model,
+                            )
+                            if not chain:
+                                continue
+
+                            ct_nodes, ct_videos = self._split_chain_for_nodes(
+                                chain, ct.nickname
+                            )
+                            nodes.extend(ct_nodes)
+                            video_queue.extend(ct_videos)
+
+                    # 发送合并转发消息
+                    if nodes:
+                        batch_label = ""
+                        if len(author_batches) > 1:
+                            batch_label = (
+                                f"（第{batch_idx + 1}/{len(author_batches)}批）"
+                            )
+                        try:
+                            message_chain = MessageChain(chain=[Nodes(nodes)])
+                            await self.context.send_message(umo, message_chain)
+                            logger.info(
+                                f"集体转发已推送至 {umo} "
+                                f"{batch_label}共 {len(nodes)} 个节点"
+                            )
+                        except Exception as node_err:
+                            logger.warning(
+                                f"集体合并转发失败，回退逐条发送: {node_err}"
+                            )
+                            # 回退：逐条发送
+                            for ct in [
+                                ct
+                                for a in batch_authors
+                                for ct in seen_authors[a]
+                            ]:
+                                await self._send_tweet_to_subscriber(
+                                    umo,
+                                    ct.username,
+                                    ct.tweet_info,
+                                    ct.sub_config,
+                                    ct.nickname,
+                                    translated_text=ct.translated_text,
+                                    translate_model=ct.translate_model,
+                                )
+                            # 回退模式下跳过独立视频发送（已在逐条发送中处理）
+                            video_queue.clear()
+
+                    # 逐条发送视频（独立消息，避免超时）
+                    for vid_comp in video_queue:
+                        await self._send_video_or_fallback(umo, vid_comp)
 
             except Exception as e:
                 logger.error(f"集体转发推送至 {umo} 失败: {e}")
@@ -1825,46 +1727,42 @@ class TwitterPlugin(Star):
         )
 
         # 构建并返回消息
-        built_message = await self._build_tweet_message_chain(
+        chain = await self._build_tweet_message_chain(
             username, tweet_info,
             translated_text=translated_text,
             translate_model=translate_model,
         )
-        try:
-            chain = built_message.chain
-            if not chain:
-                yield event.plain_result(f"未找到 @{username} 的推文内容")
-                return
+        if not chain:
+            yield event.plain_result(f"未找到 @{username} 的推文内容")
+            return
 
-            if self.use_node:
-                # 合并转发模式
-                author_username = str(tweet_info.get("username") or username)
-                screen_name = str(tweet_info.get("screen_name") or author_username)
-                nickname = self._build_author_display(author_username, screen_name)
-                try:
-                    nodes, video_parts = self._split_chain_for_nodes(chain, nickname)
-                    if nodes:
-                        yield event.chain_result([Nodes(nodes)])
-                    else:
-                        yield event.plain_result(f"未找到 @{username} 的推文内容")
-                    # 视频无法通过 yield 发送，作为独立消息发送
-                    for vid_comp in video_parts:
-                        await self._send_video_or_fallback(umo, vid_comp)
-                except Exception:
-                    # 合并转发失败，回退到普通消息链
-                    plain_chain, video_parts = self._split_plain_chain_and_videos(chain)
-                    if plain_chain:
-                        yield event.chain_result(plain_chain)
-                    for vid_comp in video_parts:
-                        await self._send_video_or_fallback(umo, vid_comp)
-            else:
+        if self.use_node:
+            # 合并转发模式
+            author_username = str(tweet_info.get("username") or username)
+            screen_name = str(tweet_info.get("screen_name") or author_username)
+            nickname = self._build_author_display(author_username, screen_name)
+            try:
+                nodes, video_parts = self._split_chain_for_nodes(chain, nickname)
+                if nodes:
+                    yield event.chain_result([Nodes(nodes)])
+                else:
+                    yield event.plain_result(f"未找到 @{username} 的推文内容")
+                # 视频无法通过 yield 发送，作为独立消息发送
+                for vid_comp in video_parts:
+                    await self._send_video_or_fallback(umo, vid_comp)
+            except Exception:
+                # 合并转发失败，回退到普通消息链
                 plain_chain, video_parts = self._split_plain_chain_and_videos(chain)
                 if plain_chain:
                     yield event.chain_result(plain_chain)
                 for vid_comp in video_parts:
                     await self._send_video_or_fallback(umo, vid_comp)
-        finally:
-            self._cleanup_temp_files(built_message.temp_files)
+        else:
+            plain_chain, video_parts = self._split_plain_chain_and_videos(chain)
+            if plain_chain:
+                yield event.chain_result(plain_chain)
+            for vid_comp in video_parts:
+                await self._send_video_or_fallback(umo, vid_comp)
 
     # ========== 链接识别 ==========
 
@@ -1892,7 +1790,6 @@ class TwitterPlugin(Star):
         if not self.twitter_api.nitter_url:
             return
 
-        built_message = BuiltTweetMessage(chain=[])
         try:
             tweet_info = await self.twitter_api.get_tweet(username, tweet_id)
 
@@ -1902,14 +1799,13 @@ class TwitterPlugin(Star):
             )
 
             # 构建推文消息链
-            built_message = await self._build_tweet_message_chain(
+            chain = await self._build_tweet_message_chain(
                 username,
                 tweet_info,
                 {"r18": True, "media": False, "status": True},
                 translated_text=translated_text,
                 translate_model=translate_model,
             )
-            chain = built_message.chain
             if not chain:
                 return
 
@@ -1942,5 +1838,3 @@ class TwitterPlugin(Star):
 
         except Exception as e:
             logger.error(f"解析推文链接失败: {e}")
-        finally:
-            self._cleanup_temp_files(built_message.temp_files)

--- a/main.py
+++ b/main.py
@@ -79,6 +79,14 @@ class CachedTweet:
     translate_model: str | None = None
 
 
+@dataclass
+class BuiltTweetMessage:
+    """已构建的消息链及其独占的临时文件。"""
+
+    chain: list
+    temp_files: list[str] = field(default_factory=list)
+
+
 class TwitterPlugin(Star):
     """Twitter 推文转发插件主类"""
 
@@ -239,7 +247,6 @@ class TwitterPlugin(Star):
 
         # 媒体临时文件管理
         self._media_temp_dir = tempfile.mkdtemp(prefix="twitter_plugin_media_")
-        self._pending_cleanup: list[str] = []
 
     async def initialize(self):
         """插件初始化"""
@@ -280,8 +287,7 @@ class TwitterPlugin(Star):
         if self._collected_tweets:
             logger.info("正在发送剩余缓存的推文...")
             await self._flush_collected_tweets()
-        # 清理媒体临时文件
-        await self._cleanup_temp_files()
+        # 清理异常退出时可能残留的媒体临时文件
         try:
             shutil.rmtree(self._media_temp_dir, ignore_errors=True)
         except Exception:
@@ -410,7 +416,12 @@ class TwitterPlugin(Star):
         return size_bytes > limit_bytes, size_bytes
 
     async def _append_media_components(
-        self, chain: list, images: list, videos: list, context_label: str = "推文"
+        self,
+        chain: list,
+        images: list,
+        videos: list,
+        temp_files: list[str],
+        context_label: str = "推文",
     ):
         """把图片和视频追加到消息链，供主贴和引用帖复用。
 
@@ -422,7 +433,9 @@ class TwitterPlugin(Star):
 
         for img_url in images:
             try:
-                img_comp = await self._build_image_component(str(img_url))
+                img_comp = await self._build_image_component(
+                    str(img_url), temp_files
+                )
                 if img_comp is not None:
                     chain.append(img_comp)
             except Exception as e:
@@ -448,7 +461,9 @@ class TwitterPlugin(Star):
                 )
                 chain.append(Comp.Plain(str(f"\n视频: {video_url}")))
 
-    async def _build_image_component(self, img_url: str) -> Comp.Image | None:
+    async def _build_image_component(
+        self, img_url: str, temp_files: list[str]
+    ) -> Comp.Image | None:
         """根据代理配置选择合适的图片组件构建方式。
 
         有代理时：通过代理下载图片到本地临时文件，使用 fromFileSystem，
@@ -476,7 +491,7 @@ class TwitterPlugin(Star):
         try:
             tmp.write(data)
             tmp.close()
-            self._pending_cleanup.append(tmp.name)
+            temp_files.append(tmp.name)
             return Comp.Image.fromFileSystem(tmp.name)
         except Exception:
             tmp.close()
@@ -496,16 +511,15 @@ class TwitterPlugin(Star):
         # Nitter /pic/orig/ 路由默认返回 JPEG
         return ".jpg"
 
-    async def _cleanup_temp_files(self):
-        """清理当前批次累积的媒体临时文件。"""
-        if not self._pending_cleanup:
-            return
-        for path in self._pending_cleanup:
+    @staticmethod
+    def _cleanup_temp_files(temp_files: list[str]) -> None:
+        """只清理当前消息拥有的媒体临时文件。"""
+        for path in temp_files:
             try:
                 os.unlink(path)
             except OSError:
                 pass
-        self._pending_cleanup.clear()
+        temp_files.clear()
 
     async def _maybe_translate(
         self, tweet_info: dict, umo: str
@@ -655,6 +669,7 @@ class TwitterPlugin(Star):
         self,
         username: str,
         tweet_info: dict,
+        temp_files: list[str],
         sub_config: dict | None = None,
         translated_text: str | None = None,
         translate_model: str | None = None,
@@ -734,12 +749,17 @@ class TwitterPlugin(Star):
                 chain,
                 quote.get("images") or [],
                 quote.get("videos") or [],
+                temp_files,
                 context_label="引用推文",
             )
 
         # 主贴媒体
         await self._append_media_components(
-            chain, images, tweet_info.get("videos") or [], context_label="推文"
+            chain,
+            images,
+            tweet_info.get("videos") or [],
+            temp_files,
+            context_label="推文",
         )
 
         # 过滤 None 值，防止类型验证错误
@@ -781,39 +801,50 @@ class TwitterPlugin(Star):
         sub_config: dict | None = None,
         translated_text: str | None = None,
         translate_model: str | None = None,
-    ) -> list:
-        """按当前文本渲染模式构建推文消息链。"""
-        if self.text_render_mode != "screenshot":
-            return await self._build_tweet_chain(
-                username,
-                tweet_info,
-                sub_config,
-                translated_text=translated_text,
-                translate_model=translate_model,
-            )
-
+    ) -> BuiltTweetMessage:
+        """按当前文本渲染模式构建推文消息链及其临时文件。"""
+        temp_files: list[str] = []
         try:
-            return await self._build_screenshot_tweet_chain(
-                username,
-                tweet_info,
-                sub_config,
-                translated_text=translated_text,
-                translate_model=translate_model,
-            )
-        except Exception as e:
-            logger.warning(f"推文截图渲染失败，已回退为文本消息: {e}")
-            return await self._build_tweet_chain(
-                username,
-                tweet_info,
-                sub_config,
-                translated_text=translated_text,
-                translate_model=translate_model,
-            )
+            if self.text_render_mode != "screenshot":
+                chain = await self._build_tweet_chain(
+                    username,
+                    tweet_info,
+                    temp_files,
+                    sub_config,
+                    translated_text=translated_text,
+                    translate_model=translate_model,
+                )
+                return BuiltTweetMessage(chain=chain, temp_files=temp_files)
+
+            try:
+                chain = await self._build_screenshot_tweet_chain(
+                    username,
+                    tweet_info,
+                    temp_files,
+                    sub_config,
+                    translated_text=translated_text,
+                    translate_model=translate_model,
+                )
+            except Exception as e:
+                logger.warning(f"推文截图渲染失败，已回退为文本消息: {e}")
+                chain = await self._build_tweet_chain(
+                    username,
+                    tweet_info,
+                    temp_files,
+                    sub_config,
+                    translated_text=translated_text,
+                    translate_model=translate_model,
+                )
+            return BuiltTweetMessage(chain=chain, temp_files=temp_files)
+        except BaseException:
+            self._cleanup_temp_files(temp_files)
+            raise
 
     async def _build_screenshot_tweet_chain(
         self,
         username: str,
         tweet_info: dict,
+        temp_files: list[str],
         sub_config: dict | None = None,
         translated_text: str | None = None,
         translate_model: str | None = None,
@@ -829,15 +860,16 @@ class TwitterPlugin(Star):
         chain: list = []
         has_media = self._tweet_has_media(tweet_info)
         render_text_card = not (self.no_text and has_media)
+        render_tweet_info = tweet_info
 
         if render_text_card:
             # 预下载模式：将图片转为 data URI 内嵌，HTML 渲染零外部请求
             if self.pre_download_media and self.proxy:
-                tweet_info = await self._prepare_screenshot_media(tweet_info)
+                render_tweet_info = await self._prepare_screenshot_media(tweet_info)
 
             context = build_tweet_card_context(
                 username,
-                tweet_info,
+                render_tweet_info,
                 translated_text=translated_text,
                 translate_model=translate_model,
                 theme=self.screenshot_theme,
@@ -864,6 +896,7 @@ class TwitterPlugin(Star):
                 chain,
                 quote.get("images") or [],
                 quote.get("videos") or [],
+                temp_files,
                 context_label="引用推文",
             )
 
@@ -871,11 +904,9 @@ class TwitterPlugin(Star):
             chain,
             tweet_info.get("images") or [],
             tweet_info.get("videos") or [],
+            temp_files,
             context_label="推文",
         )
-
-        # 及时清理截图流程中创建的临时文件
-        await self._cleanup_temp_files()
 
         return [c for c in chain if c is not None]
 
@@ -1158,12 +1189,14 @@ class TwitterPlugin(Star):
         translate_model: str | None = None,
     ):
         """向单个订阅者发送推文消息"""
+        built_message = BuiltTweetMessage(chain=[])
         try:
-            chain = await self._build_tweet_message_chain(
+            built_message = await self._build_tweet_message_chain(
                 username, tweet_info, sub_config,
                 translated_text=translated_text,
                 translate_model=translate_model,
             )
+            chain = built_message.chain
             if not chain:
                 return
 
@@ -1205,7 +1238,77 @@ class TwitterPlugin(Star):
         except Exception as e:
             logger.error(f"推送推文至 {umo} 失败: {e}")
         finally:
-            await self._cleanup_temp_files()
+            self._cleanup_temp_files(built_message.temp_files)
+
+    async def _send_collected_batch(
+        self,
+        umo: str,
+        batch_authors: list[str],
+        seen_authors: dict[str, list[CachedTweet]],
+        batch_index: int,
+        batch_count: int,
+    ) -> None:
+        """发送一批集体转发消息，并清理该批次独占的临时文件。"""
+        temp_files: list[str] = []
+        nodes: list[Node] = []
+        video_queue: list[Comp.Video] = []
+
+        try:
+            for author in batch_authors:
+                for cached_tweet in seen_authors[author]:
+                    built_message = await self._build_tweet_message_chain(
+                        cached_tweet.username,
+                        cached_tweet.tweet_info,
+                        cached_tweet.sub_config,
+                        translated_text=cached_tweet.translated_text,
+                        translate_model=cached_tweet.translate_model,
+                    )
+                    temp_files.extend(built_message.temp_files)
+                    if not built_message.chain:
+                        continue
+
+                    tweet_nodes, tweet_videos = self._split_chain_for_nodes(
+                        built_message.chain, cached_tweet.nickname
+                    )
+                    nodes.extend(tweet_nodes)
+                    video_queue.extend(tweet_videos)
+
+            if nodes:
+                batch_label = ""
+                if batch_count > 1:
+                    batch_label = f"（第{batch_index + 1}/{batch_count}批）"
+                try:
+                    message_chain = MessageChain(chain=[Nodes(nodes)])
+                    await self.context.send_message(umo, message_chain)
+                    logger.info(
+                        f"集体转发已推送至 {umo} "
+                        f"{batch_label}共 {len(nodes)} 个节点"
+                    )
+                except Exception as node_err:
+                    logger.warning(
+                        f"集体合并转发失败，回退逐条发送: {node_err}"
+                    )
+                    for cached_tweet in [
+                        cached_tweet
+                        for author in batch_authors
+                        for cached_tweet in seen_authors[author]
+                    ]:
+                        await self._send_tweet_to_subscriber(
+                            umo,
+                            cached_tweet.username,
+                            cached_tweet.tweet_info,
+                            cached_tweet.sub_config,
+                            cached_tweet.nickname,
+                            translated_text=cached_tweet.translated_text,
+                            translate_model=cached_tweet.translate_model,
+                        )
+                    # 回退逐条发送已包含视频，不再重复发送。
+                    video_queue.clear()
+
+            for video_component in video_queue:
+                await self._send_video_or_fallback(umo, video_component)
+        finally:
+            self._cleanup_temp_files(temp_files)
 
     async def _flush_collected_tweets(self):
         """将缓存的推文按推主分组打包为合并转发消息发送"""
@@ -1260,64 +1363,13 @@ class TwitterPlugin(Star):
                     author_batches.append(author_order[i : i + max_authors])
 
                 for batch_idx, batch_authors in enumerate(author_batches):
-                    nodes: list[Node] = []
-                    video_queue: list[Comp.Video] = []
-
-                    for author in batch_authors:
-                        for ct in seen_authors[author]:
-                            chain = await self._build_tweet_message_chain(
-                                ct.username, ct.tweet_info, ct.sub_config,
-                                translated_text=ct.translated_text,
-                                translate_model=ct.translate_model,
-                            )
-                            if not chain:
-                                continue
-
-                            ct_nodes, ct_videos = self._split_chain_for_nodes(
-                                chain, ct.nickname
-                            )
-                            nodes.extend(ct_nodes)
-                            video_queue.extend(ct_videos)
-
-                    # 发送合并转发消息
-                    if nodes:
-                        batch_label = ""
-                        if len(author_batches) > 1:
-                            batch_label = (
-                                f"（第{batch_idx + 1}/{len(author_batches)}批）"
-                            )
-                        try:
-                            message_chain = MessageChain(chain=[Nodes(nodes)])
-                            await self.context.send_message(umo, message_chain)
-                            logger.info(
-                                f"集体转发已推送至 {umo} "
-                                f"{batch_label}共 {len(nodes)} 个节点"
-                            )
-                        except Exception as node_err:
-                            logger.warning(
-                                f"集体合并转发失败，回退逐条发送: {node_err}"
-                            )
-                            # 回退：逐条发送
-                            for ct in [
-                                ct
-                                for a in batch_authors
-                                for ct in seen_authors[a]
-                            ]:
-                                await self._send_tweet_to_subscriber(
-                                    umo,
-                                    ct.username,
-                                    ct.tweet_info,
-                                    ct.sub_config,
-                                    ct.nickname,
-                                    translated_text=ct.translated_text,
-                                    translate_model=ct.translate_model,
-                                )
-                            # 回退模式下跳过独立视频发送（已在逐条发送中处理）
-                            video_queue.clear()
-
-                    # 逐条发送视频（独立消息，避免超时）
-                    for vid_comp in video_queue:
-                        await self._send_video_or_fallback(umo, vid_comp)
+                    await self._send_collected_batch(
+                        umo,
+                        batch_authors,
+                        seen_authors,
+                        batch_idx,
+                        len(author_batches),
+                    )
 
             except Exception as e:
                 logger.error(f"集体转发推送至 {umo} 失败: {e}")
@@ -1773,44 +1825,46 @@ class TwitterPlugin(Star):
         )
 
         # 构建并返回消息
-        chain = await self._build_tweet_message_chain(
+        built_message = await self._build_tweet_message_chain(
             username, tweet_info,
             translated_text=translated_text,
             translate_model=translate_model,
         )
-        if not chain:
-            yield event.plain_result(f"未找到 @{username} 的推文内容")
-            return
+        try:
+            chain = built_message.chain
+            if not chain:
+                yield event.plain_result(f"未找到 @{username} 的推文内容")
+                return
 
-        if self.use_node:
-            # 合并转发模式
-            author_username = str(tweet_info.get("username") or username)
-            screen_name = str(tweet_info.get("screen_name") or author_username)
-            nickname = self._build_author_display(author_username, screen_name)
-            try:
-                nodes, video_parts = self._split_chain_for_nodes(chain, nickname)
-                if nodes:
-                    yield event.chain_result([Nodes(nodes)])
-                else:
-                    yield event.plain_result(f"未找到 @{username} 的推文内容")
-                # 视频无法通过 yield 发送，作为独立消息发送
-                for vid_comp in video_parts:
-                    await self._send_video_or_fallback(umo, vid_comp)
-            except Exception:
-                # 合并转发失败，回退到普通消息链
+            if self.use_node:
+                # 合并转发模式
+                author_username = str(tweet_info.get("username") or username)
+                screen_name = str(tweet_info.get("screen_name") or author_username)
+                nickname = self._build_author_display(author_username, screen_name)
+                try:
+                    nodes, video_parts = self._split_chain_for_nodes(chain, nickname)
+                    if nodes:
+                        yield event.chain_result([Nodes(nodes)])
+                    else:
+                        yield event.plain_result(f"未找到 @{username} 的推文内容")
+                    # 视频无法通过 yield 发送，作为独立消息发送
+                    for vid_comp in video_parts:
+                        await self._send_video_or_fallback(umo, vid_comp)
+                except Exception:
+                    # 合并转发失败，回退到普通消息链
+                    plain_chain, video_parts = self._split_plain_chain_and_videos(chain)
+                    if plain_chain:
+                        yield event.chain_result(plain_chain)
+                    for vid_comp in video_parts:
+                        await self._send_video_or_fallback(umo, vid_comp)
+            else:
                 plain_chain, video_parts = self._split_plain_chain_and_videos(chain)
                 if plain_chain:
                     yield event.chain_result(plain_chain)
                 for vid_comp in video_parts:
                     await self._send_video_or_fallback(umo, vid_comp)
-        else:
-            plain_chain, video_parts = self._split_plain_chain_and_videos(chain)
-            if plain_chain:
-                yield event.chain_result(plain_chain)
-            for vid_comp in video_parts:
-                await self._send_video_or_fallback(umo, vid_comp)
-
-        await self._cleanup_temp_files()
+        finally:
+            self._cleanup_temp_files(built_message.temp_files)
 
     # ========== 链接识别 ==========
 
@@ -1838,6 +1892,7 @@ class TwitterPlugin(Star):
         if not self.twitter_api.nitter_url:
             return
 
+        built_message = BuiltTweetMessage(chain=[])
         try:
             tweet_info = await self.twitter_api.get_tweet(username, tweet_id)
 
@@ -1847,13 +1902,14 @@ class TwitterPlugin(Star):
             )
 
             # 构建推文消息链
-            chain = await self._build_tweet_message_chain(
+            built_message = await self._build_tweet_message_chain(
                 username,
                 tweet_info,
                 {"r18": True, "media": False, "status": True},
                 translated_text=translated_text,
                 translate_model=translate_model,
             )
+            chain = built_message.chain
             if not chain:
                 return
 
@@ -1887,4 +1943,4 @@ class TwitterPlugin(Star):
         except Exception as e:
             logger.error(f"解析推文链接失败: {e}")
         finally:
-            await self._cleanup_temp_files()
+            self._cleanup_temp_files(built_message.temp_files)

--- a/tests/test_media_lifecycle.py
+++ b/tests/test_media_lifecycle.py
@@ -1,0 +1,264 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class _Logger:
+    def __getattr__(self, _name):
+        return lambda *_args, **_kwargs: None
+
+
+class _Component:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class Plain(_Component):
+    def __init__(self, text):
+        super().__init__(text=text)
+
+
+class Image(_Component):
+    @staticmethod
+    def fromURL(url):
+        if not url.startswith(("http://", "https://")):
+            raise ValueError("not a valid URL")
+        return Image(file=url)
+
+    @staticmethod
+    def fromFileSystem(path):
+        return Image(file=Path(path).resolve().as_uri(), path=str(Path(path).resolve()))
+
+
+class Video(_Component):
+    @staticmethod
+    def fromURL(url):
+        return Video(file=url)
+
+
+class Node(_Component):
+    def __init__(self, content, name):
+        super().__init__(content=content, name=name)
+
+
+class Nodes(_Component):
+    def __init__(self, nodes):
+        super().__init__(nodes=nodes)
+
+
+class MessageChain(_Component):
+    def __init__(self, chain):
+        super().__init__(chain=chain)
+
+
+def _decorator(*_args, **_kwargs):
+    return lambda func: func
+
+
+def _load_main_module():
+    package_name = "twitter_plugin_test_package"
+    for module_name in list(sys.modules):
+        if module_name == package_name or module_name.startswith(f"{package_name}."):
+            del sys.modules[module_name]
+
+    astrbot = types.ModuleType("astrbot")
+    api = types.ModuleType("astrbot.api")
+    event = types.ModuleType("astrbot.api.event")
+    components = types.ModuleType("astrbot.api.message_components")
+    star = types.ModuleType("astrbot.api.star")
+
+    api.AstrBotConfig = dict
+    api.logger = _Logger()
+    event.AstrMessageEvent = object
+    event.MessageChain = MessageChain
+    event.filter = types.SimpleNamespace(
+        command=_decorator,
+        event_message_type=_decorator,
+        permission_type=_decorator,
+        EventMessageType=types.SimpleNamespace(ALL="all"),
+        PermissionType=types.SimpleNamespace(ADMIN="admin"),
+    )
+    components.Plain = Plain
+    components.Image = Image
+    components.Video = Video
+    components.Node = Node
+    components.Nodes = Nodes
+
+    class Star:
+        def __init__(self, context):
+            self.context = context
+
+    star.Context = object
+    star.Star = Star
+
+    sys.modules.update(
+        {
+            "astrbot": astrbot,
+            "astrbot.api": api,
+            "astrbot.api.event": event,
+            "astrbot.api.message_components": components,
+            "astrbot.api.star": star,
+        }
+    )
+
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(ROOT)]
+    sys.modules[package_name] = package
+
+    twitter_api = types.ModuleType(f"{package_name}.twitter_api")
+    twitter_api.TwitterAPI = object
+    twitter_api.WEBSITE_LIST = []
+    twitter_api.get_next_website = lambda *_args, **_kwargs: None
+    sys.modules[twitter_api.__name__] = twitter_api
+
+    spec = importlib.util.spec_from_file_location(
+        f"{package_name}.main", ROOT / "main.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def plugin_module():
+    return _load_main_module()
+
+
+@pytest.mark.asyncio
+async def test_screenshot_uses_prepared_copy_but_sends_original_media(
+    plugin_module, tmp_path
+):
+    plugin = plugin_module.TwitterPlugin.__new__(plugin_module.TwitterPlugin)
+    plugin.no_text = False
+    plugin.pre_download_media = True
+    plugin.proxy = "http://127.0.0.1:7890"
+    plugin.screenshot_theme = "dark"
+    plugin.include_tweet_link = False
+
+    original_url = "https://example.com/original.jpg"
+    prepared_url = "data:image/jpeg;base64,cHJlcGFyZWQ="
+    tweet_info = {
+        "username": "tester",
+        "tweet_id": "1",
+        "images": [original_url],
+    }
+    captured_media = []
+    captured_context = {}
+
+    async def prepare_screenshot_media(_tweet_info):
+        prepared = dict(_tweet_info)
+        prepared["images"] = [prepared_url]
+        return prepared
+
+    async def html_render(_template, context, options):
+        captured_context.update(context)
+        assert options
+        return str(tmp_path / "card.png")
+
+    async def append_media(
+        _chain, images, _videos, _temp_files, context_label="推文"
+    ):
+        captured_media.append((context_label, list(images)))
+
+    plugin._prepare_screenshot_media = prepare_screenshot_media
+    plugin.html_render = html_render
+    plugin._append_media_components = append_media
+
+    await plugin._build_screenshot_tweet_chain(
+        "tester", tweet_info, [], {"r18": True, "media": False, "status": True}
+    )
+
+    assert captured_context["tweet"]["media"][0]["url"] == prepared_url
+    assert captured_media == [("推文", [original_url])]
+    assert tweet_info["images"] == [original_url]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sends_only_clean_their_own_files(plugin_module, tmp_path):
+    plugin = plugin_module.TwitterPlugin.__new__(plugin_module.TwitterPlugin)
+    plugin.use_node = False
+    first_path = tmp_path / "first.jpg"
+    second_path = tmp_path / "second.jpg"
+    first_path.write_bytes(b"first")
+    second_path.write_bytes(b"second")
+    paths = {"first": first_path, "second": second_path}
+
+    second_started = asyncio.Event()
+    release_second = asyncio.Event()
+
+    class Context:
+        async def send_message(self, umo, _message_chain):
+            assert paths[umo].exists()
+            if umo == "second":
+                second_started.set()
+                await release_second.wait()
+
+    async def build_message(username, *_args, **_kwargs):
+        path = paths[username]
+        return plugin_module.BuiltTweetMessage(
+            chain=[Image.fromFileSystem(path)],
+            temp_files=[str(path)],
+        )
+
+    plugin.context = Context()
+    plugin._build_tweet_message_chain = build_message
+
+    second_task = asyncio.create_task(
+        plugin._send_tweet_to_subscriber(
+            "second", "second", {}, {}, "second"
+        )
+    )
+    await second_started.wait()
+    await plugin._send_tweet_to_subscriber("first", "first", {}, {}, "first")
+
+    assert not first_path.exists()
+    assert second_path.exists()
+
+    release_second.set()
+    await second_task
+    assert not second_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_collective_batch_cleans_files_after_success(plugin_module, tmp_path):
+    plugin = plugin_module.TwitterPlugin.__new__(plugin_module.TwitterPlugin)
+    media_path = tmp_path / "collective.jpg"
+    media_path.write_bytes(b"collective")
+    sent = False
+
+    class Context:
+        async def send_message(self, _umo, _message_chain):
+            nonlocal sent
+            assert media_path.exists()
+            sent = True
+
+    async def build_message(*_args, **_kwargs):
+        return plugin_module.BuiltTweetMessage(
+            chain=[Image.fromFileSystem(media_path)],
+            temp_files=[str(media_path)],
+        )
+
+    plugin.context = Context()
+    plugin._build_tweet_message_chain = build_message
+    plugin._send_video_or_fallback = lambda *_args, **_kwargs: None
+    cached_tweet = plugin_module.CachedTweet(
+        username="tester",
+        tweet_info={},
+        sub_config={},
+        nickname="tester",
+    )
+
+    await plugin._send_collected_batch(
+        "umo", ["tester"], {"tester": [cached_tweet]}, 0, 1
+    )
+
+    assert sent
+    assert not media_path.exists()

--- a/tests/test_media_lifecycle.py
+++ b/tests/test_media_lifecycle.py
@@ -1,4 +1,3 @@
-import asyncio
 import importlib.util
 import sys
 import types
@@ -35,6 +34,10 @@ class Image(_Component):
     @staticmethod
     def fromFileSystem(path):
         return Image(file=Path(path).resolve().as_uri(), path=str(Path(path).resolve()))
+
+    @staticmethod
+    def fromBytes(data):
+        return Image(data=data)
 
 
 class Video(_Component):
@@ -163,9 +166,7 @@ async def test_screenshot_uses_prepared_copy_but_sends_original_media(
         assert options
         return str(tmp_path / "card.png")
 
-    async def append_media(
-        _chain, images, _videos, _temp_files, context_label="推文"
-    ):
+    async def append_media(_chain, images, _videos, context_label="推文"):
         captured_media.append((context_label, list(images)))
 
     plugin._prepare_screenshot_media = prepare_screenshot_media
@@ -173,7 +174,7 @@ async def test_screenshot_uses_prepared_copy_but_sends_original_media(
     plugin._append_media_components = append_media
 
     await plugin._build_screenshot_tweet_chain(
-        "tester", tweet_info, [], {"r18": True, "media": False, "status": True}
+        "tester", tweet_info, {"r18": True, "media": False, "status": True}
     )
 
     assert captured_context["tweet"]["media"][0]["url"] == prepared_url
@@ -182,83 +183,41 @@ async def test_screenshot_uses_prepared_copy_but_sends_original_media(
 
 
 @pytest.mark.asyncio
-async def test_concurrent_sends_only_clean_their_own_files(plugin_module, tmp_path):
+async def test_pre_downloaded_image_uses_from_bytes(plugin_module):
     plugin = plugin_module.TwitterPlugin.__new__(plugin_module.TwitterPlugin)
-    plugin.use_node = False
-    first_path = tmp_path / "first.jpg"
-    second_path = tmp_path / "second.jpg"
-    first_path.write_bytes(b"first")
-    second_path.write_bytes(b"second")
-    paths = {"first": first_path, "second": second_path}
+    plugin.pre_download_media = True
+    plugin.proxy = "http://127.0.0.1:7890"
+    image_bytes = b"downloaded-image"
 
-    second_started = asyncio.Event()
-    release_second = asyncio.Event()
+    class TwitterAPI:
+        async def download_media(self, url):
+            assert url == "https://example.com/image.jpg"
+            return image_bytes
 
-    class Context:
-        async def send_message(self, umo, _message_chain):
-            assert paths[umo].exists()
-            if umo == "second":
-                second_started.set()
-                await release_second.wait()
+    plugin.twitter_api = TwitterAPI()
 
-    async def build_message(username, *_args, **_kwargs):
-        path = paths[username]
-        return plugin_module.BuiltTweetMessage(
-            chain=[Image.fromFileSystem(path)],
-            temp_files=[str(path)],
-        )
-
-    plugin.context = Context()
-    plugin._build_tweet_message_chain = build_message
-
-    second_task = asyncio.create_task(
-        plugin._send_tweet_to_subscriber(
-            "second", "second", {}, {}, "second"
-        )
+    component = await plugin._build_image_component(
+        "https://example.com/image.jpg"
     )
-    await second_started.wait()
-    await plugin._send_tweet_to_subscriber("first", "first", {}, {}, "first")
 
-    assert not first_path.exists()
-    assert second_path.exists()
-
-    release_second.set()
-    await second_task
-    assert not second_path.exists()
+    assert isinstance(component, Image)
+    assert component.data == image_bytes
 
 
 @pytest.mark.asyncio
-async def test_collective_batch_cleans_files_after_success(plugin_module, tmp_path):
+async def test_pre_download_failure_falls_back_to_remote_url(plugin_module):
     plugin = plugin_module.TwitterPlugin.__new__(plugin_module.TwitterPlugin)
-    media_path = tmp_path / "collective.jpg"
-    media_path.write_bytes(b"collective")
-    sent = False
+    plugin.pre_download_media = True
+    plugin.proxy = "http://127.0.0.1:7890"
 
-    class Context:
-        async def send_message(self, _umo, _message_chain):
-            nonlocal sent
-            assert media_path.exists()
-            sent = True
+    class TwitterAPI:
+        async def download_media(self, _url):
+            raise RuntimeError("proxy unavailable")
 
-    async def build_message(*_args, **_kwargs):
-        return plugin_module.BuiltTweetMessage(
-            chain=[Image.fromFileSystem(media_path)],
-            temp_files=[str(media_path)],
-        )
+    plugin.twitter_api = TwitterAPI()
+    image_url = "https://example.com/image.jpg"
 
-    plugin.context = Context()
-    plugin._build_tweet_message_chain = build_message
-    plugin._send_video_or_fallback = lambda *_args, **_kwargs: None
-    cached_tweet = plugin_module.CachedTweet(
-        username="tester",
-        tweet_info={},
-        sub_config={},
-        nickname="tester",
-    )
+    component = await plugin._build_image_component(image_url)
 
-    await plugin._send_collected_batch(
-        "umo", ["tester"], {"tester": [cached_tweet]}, 0, 1
-    )
-
-    assert sent
-    assert not media_path.exists()
+    assert isinstance(component, Image)
+    assert component.file == image_url

--- a/twitter_api.py
+++ b/twitter_api.py
@@ -3,6 +3,7 @@ Twitter API 交互模块
 通过 Nitter 镜像站获取 Twitter/X 推文数据
 """
 
+import base64
 import re
 from typing import Optional
 
@@ -51,6 +52,68 @@ class TwitterAPI:
                 },
             )
         return self._client
+
+    async def download_media(self, url: str) -> bytes:
+        """通过已配置代理的 HTTP 客户端下载媒体文件。
+
+        将远程 URL 转换为本地字节数据，避免下游消费者（消息适配器、
+        HTML 渲染器）直连可能受网络限制的外部服务器。
+
+        参数:
+            url: 远程媒体文件 URL
+
+        返回:
+            媒体文件的原始字节数据
+
+        异常:
+            ValueError: URL 为空
+            httpx.HTTPStatusError: 响应状态码非 2xx
+        """
+        url = str(url or "").strip()
+        if not url:
+            raise ValueError("empty URL")
+
+        client = await self._get_client()
+        resp = await client.get(url, timeout=30.0)
+        resp.raise_for_status()
+        return resp.content
+
+    async def download_media_to_data_uri(self, url: str) -> str:
+        """下载媒体文件并转换为 data URI（base64 内嵌）。
+
+        用于截图模式的 HTML 渲染——将图片转为 data: URI 后内嵌到 HTML，
+        Playwright/Chromium 渲染时无需发起外部网络请求。
+
+        参数:
+            url: 远程媒体文件 URL
+
+        返回:
+            data: URI 字符串，如 data:image/png;base64,...
+
+        异常:
+            ValueError: URL 为空
+            httpx.HTTPStatusError: 响应状态码非 2xx
+        """
+        data = await self.download_media(url)
+        mime = self._guess_mime_from_url(url)
+        b64 = base64.b64encode(data).decode("ascii")
+        return f"data:{mime};base64,{b64}"
+
+    @staticmethod
+    def _guess_mime_from_url(url: str) -> str:
+        """根据 URL 后缀推测 MIME 类型，默认 image/jpeg。"""
+        url_lower = str(url or "").lower()
+        for ext, mime in [
+            (".png", "image/png"),
+            (".gif", "image/gif"),
+            (".webp", "image/webp"),
+            (".svg", "image/svg+xml"),
+            (".bmp", "image/bmp"),
+            (".mp4", "video/mp4"),
+        ]:
+            if ext in url_lower:
+                return mime
+        return "image/jpeg"
 
     async def close(self):
         """关闭 HTTP 客户端"""


### PR DESCRIPTION
## 问题

在网络受限环境（需代理访问境外站点）下，插件通过代理获取推文 **JSON 数据** 正常，但消息发送和截图渲染阶段失败：

| 阶段 | 谁负责 HTTP | 能否访问代理 | 结果 |
|------|------------|-------------|------|
| 推文数据拉取 | 插件 `httpx` | ✅ 已配代理 | 正常 |
| 图片消息发送 | AstrBot 核心/适配器 | ❌ 无代理 | 超时 |
| 截图 HTML 渲染 | Chromium (Playwright) | ❌ 无代理 | 超时 |

**根因**：插件把「需要代理才能访问的 URL」作为中间产物传给不知道代理的下游消费者。

## 修复

新增 `twitter_pre_download_media` 配置项（**默认关闭**，完全向后兼容）。

开启且配置了代理后：

- **文本模式**：图片通过代理下载为字节数据，再用 `Comp.Image.fromBytes` 创建图片组件，消息适配器不再请求远程 URL
- **截图模式**：头像、图片和视频封面预下载后转为 base64 data URI 并内嵌 HTML，Chromium 无需发起外部请求

### 新增 API（`twitter_api.py`）

- `download_media(url) -> bytes` — 通过已配置代理的 httpx 客户端下载媒体
- `download_media_to_data_uri(url) -> str` — 下载并转为 `data:image/...;base64,...`

### 配置 UI

AstrBot 配置面板「基础设置」新增「通过代理预下载图片」开关。